### PR TITLE
Add tracking functionalities to most state changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cellpop",
   "private": false,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "author": "Thomas Smits",
   "description": "A React component for visualizing cell populations in two-dimensional array data.",

--- a/src/CellPopComponent.tsx
+++ b/src/CellPopComponent.tsx
@@ -9,7 +9,6 @@ import { OuterContainerRefProvider } from "./contexts/ContainerRefContext";
 import { Dimensions, GridSizeTuple } from "./contexts/DimensionsContext";
 import { Providers } from "./contexts/Providers";
 import { loadHuBMAPData } from "./dataLoading";
-import Controls from "./visx-visualization/Controls";
 import VizContainer from "./visx-visualization/layout";
 
 type DisableableControls = "fraction" | "selection" | "theme";
@@ -26,6 +25,11 @@ interface CellPopConfig {
   fieldDisplayNames?: Record<string, string>;
   sortableFields?: string[];
   tooltipFields?: string[];
+  trackEvent?: (
+    event: string,
+    detail: string,
+    extra?: Record<string, unknown>,
+  ) => void;
 }
 
 export interface CellPopProps
@@ -52,6 +56,7 @@ export const CellPop = withParentSize(
     fieldDisplayNames,
     sortableFields,
     tooltipFields,
+    trackEvent,
   }: CellPopProps) => {
     // If dimensions are provided, use them.
     // Otherwise, fall back to using parentWidth and parentHeight.
@@ -94,6 +99,7 @@ export const CellPop = withParentSize(
             fieldDisplayNames={fieldDisplayNames}
             sortableFields={sortableFields}
             tooltipFields={tooltipFields}
+            trackEvent={trackEvent}
           >
             <VizContainer />
           </Providers>

--- a/src/contexts/EventTrackerProvider.tsx
+++ b/src/contexts/EventTrackerProvider.tsx
@@ -1,0 +1,30 @@
+import React, { PropsWithChildren } from "react";
+import { createContext, useContext } from "../utils/context";
+
+type EventTrackerContextValue = (
+  event: string,
+  detail: string,
+  extra?: Record<string, unknown>,
+) => void;
+
+const EventTrackerContext = createContext<EventTrackerContextValue>(
+  "Event Tracker Context Value",
+);
+
+// Placeholder function to prevent errors when no event tracker is provided
+const noOp = () => {};
+
+export const EventTrackerProvider = ({
+  trackEvent = noOp,
+  children,
+}: PropsWithChildren<{
+  trackEvent?: EventTrackerContextValue;
+}>) => {
+  return (
+    <EventTrackerContext.Provider value={trackEvent}>
+      {children}
+    </EventTrackerContext.Provider>
+  );
+};
+
+export const useTrackEvent = () => useContext(EventTrackerContext);

--- a/src/contexts/Providers.tsx
+++ b/src/contexts/Providers.tsx
@@ -19,6 +19,7 @@ import {
   DisableableControls,
   DisabledControlProvider,
 } from "./DisabledControlProvider";
+import { EventTrackerProvider } from "./EventTrackerProvider";
 import { SelectedValuesProvider } from "./ExpandedValuesContext";
 import { FractionProvider } from "./FractionContext";
 import { MetadataConfigProvider } from "./MetadataConfigContext";
@@ -43,6 +44,11 @@ interface CellPopConfigProps extends PropsWithChildren {
   fieldDisplayNames?: Record<string, string>;
   sortableFields?: string[];
   tooltipFields?: string[];
+  trackEvent?: (
+    event: string,
+    detail: string,
+    extra?: Record<string, unknown>,
+  ) => void;
 }
 
 export function Providers({
@@ -62,47 +68,50 @@ export function Providers({
   fieldDisplayNames,
   sortableFields,
   tooltipFields,
+  trackEvent,
 }: CellPopConfigProps) {
   return (
-    <DisabledControlProvider disabledControls={disabledControls}>
-      <DataProvider initialData={data}>
-        <SelectedValuesProvider initialSelectedValues={selectedValues}>
-          <RowConfigProvider {...yAxisConfig}>
-            <ColumnConfigProvider {...xAxisConfig}>
-              <TooltipDataProvider>
-                <CellPopThemeProvider theme={theme} customTheme={customTheme}>
-                  <DimensionsProvider
-                    dimensions={dimensions}
-                    initialProportions={initialProportions}
-                  >
-                    <FractionProvider initialFraction={fraction}>
-                      <NormalizationProvider
-                        initialNormalization={initialNormalization}
-                      >
-                        <ScaleProvider>
-                          <ColorScaleProvider>
-                            <SelectedDimensionProvider
-                              initialSelectedDimension={selectedDimension}
-                            >
-                              <MetadataConfigProvider
-                                fieldDisplayNames={fieldDisplayNames}
-                                sortableFields={sortableFields}
-                                tooltipFields={tooltipFields}
+    <EventTrackerProvider trackEvent={trackEvent}>
+      <DisabledControlProvider disabledControls={disabledControls}>
+        <DataProvider initialData={data}>
+          <SelectedValuesProvider initialSelectedValues={selectedValues}>
+            <RowConfigProvider {...yAxisConfig}>
+              <ColumnConfigProvider {...xAxisConfig}>
+                <TooltipDataProvider>
+                  <CellPopThemeProvider theme={theme} customTheme={customTheme}>
+                    <DimensionsProvider
+                      dimensions={dimensions}
+                      initialProportions={initialProportions}
+                    >
+                      <FractionProvider initialFraction={fraction}>
+                        <NormalizationProvider
+                          initialNormalization={initialNormalization}
+                        >
+                          <ScaleProvider>
+                            <ColorScaleProvider>
+                              <SelectedDimensionProvider
+                                initialSelectedDimension={selectedDimension}
                               >
-                                {children}
-                              </MetadataConfigProvider>
-                            </SelectedDimensionProvider>
-                          </ColorScaleProvider>
-                        </ScaleProvider>
-                      </NormalizationProvider>
-                    </FractionProvider>
-                  </DimensionsProvider>
-                </CellPopThemeProvider>
-              </TooltipDataProvider>
-            </ColumnConfigProvider>
-          </RowConfigProvider>
-        </SelectedValuesProvider>
-      </DataProvider>
-    </DisabledControlProvider>
+                                <MetadataConfigProvider
+                                  fieldDisplayNames={fieldDisplayNames}
+                                  sortableFields={sortableFields}
+                                  tooltipFields={tooltipFields}
+                                >
+                                  {children}
+                                </MetadataConfigProvider>
+                              </SelectedDimensionProvider>
+                            </ColorScaleProvider>
+                          </ScaleProvider>
+                        </NormalizationProvider>
+                      </FractionProvider>
+                    </DimensionsProvider>
+                  </CellPopThemeProvider>
+                </TooltipDataProvider>
+              </ColumnConfigProvider>
+            </RowConfigProvider>
+          </SelectedValuesProvider>
+        </DataProvider>
+      </DisabledControlProvider>
+    </EventTrackerProvider>
   );
 }

--- a/src/visx-visualization/Controls.tsx
+++ b/src/visx-visualization/Controls.tsx
@@ -15,6 +15,7 @@ import {
   useNormalizationControlIsDisabled,
   useThemeControlIsDisabled,
 } from "../contexts/DisabledControlProvider";
+import { useTrackEvent } from "../contexts/EventTrackerProvider";
 import { useFraction } from "../contexts/FractionContext";
 import {
   NORMALIZATIONS,
@@ -25,9 +26,11 @@ import LabelledSwitch from "./LabelledSwitch";
 
 function HeatmapThemeControl() {
   const { setHeatmapTheme, heatmapTheme } = useColorScale();
+  const trackEvent = useTrackEvent();
 
   const handleThemeChange = useEventCallback((e: SelectChangeEvent) => {
     setHeatmapTheme(e.target.value as HeatmapTheme);
+    trackEvent("Change Heatmap Theme", e.target.value);
   });
   return (
     <FormControl sx={{ maxWidth: 300 }}>
@@ -59,11 +62,13 @@ function ThemeControl() {
   const themeIsDisabled = useThemeControlIsDisabled();
 
   const { currentTheme, setTheme } = useSetTheme();
+  const trackEvent = useTrackEvent();
 
   const changeVisTheme = useEventCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const newTheme = e.target.checked ? "dark" : "light";
       setTheme(newTheme);
+      trackEvent("Change Visualization Theme", newTheme);
     },
   );
   if (themeIsDisabled) {
@@ -83,10 +88,13 @@ function ThemeControl() {
 
 function FractionControl() {
   const { fraction, setFraction } = useFraction();
+  const trackEvent = useTrackEvent();
   const changeFraction = useEventCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const newFraction = Boolean(event.target.checked);
       setFraction(newFraction);
+      const fraction = newFraction ? "Fraction" : "Count";
+      trackEvent("Change Graph Type", fraction);
     },
   );
   const fractionIsDisabled = useFractionControlIsDisabled();
@@ -111,11 +119,12 @@ function FractionControl() {
 function SelectedDimensionControl() {
   const selectedDimensionIsDisabled = useFractionControlIsDisabled();
   const { selectedDimension, setSelectedDimension } = useSelectedDimension();
-
+  const trackEvent = useTrackEvent();
   const changeSelectedDimension = useEventCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       const newSelectedDimension = event.target.checked ? "X" : "Y";
       setSelectedDimension(newSelectedDimension);
+      trackEvent("Change Control Orientation", newSelectedDimension);
     },
   );
 

--- a/src/visx-visualization/TemporalControls.tsx
+++ b/src/visx-visualization/TemporalControls.tsx
@@ -10,6 +10,7 @@ import { StoreApi } from "zustand";
 import { useThemeHistory } from "../contexts/CellPopThemeContext";
 import { useDataHistory } from "../contexts/DataContext";
 import { useThemeControlIsDisabled } from "../contexts/DisabledControlProvider";
+import { useTrackEvent } from "../contexts/EventTrackerProvider";
 import { useExpandedValuesHistory } from "../contexts/ExpandedValuesContext";
 import { useFractionHistory } from "../contexts/FractionContext";
 import { useNormalizationHistory } from "../contexts/NormalizationContext";
@@ -31,6 +32,8 @@ function useTemporalActions() {
 
   const undoQueue = useRef<TemporalState<StoreApi<unknown>>[]>([]);
   const redoQueue = useRef<TemporalState<StoreApi<unknown>>[]>([]);
+
+  const trackEvent = useTrackEvent();
 
   useEffect(() => {
     const onSave = (state: TemporalState<StoreApi<unknown>>) => () => {
@@ -66,6 +69,7 @@ function useTemporalActions() {
     if (last) {
       last.undo();
       redoQueue.current.push(last);
+      trackEvent("Undo Last Action", "");
     }
   });
 
@@ -74,6 +78,7 @@ function useTemporalActions() {
     if (last) {
       last.redo();
       undoQueue.current.push(last);
+      trackEvent("Redo Last Action", "");
     }
   });
 
@@ -86,6 +91,7 @@ function useTemporalActions() {
     normalizationHistory.undo(normalizationHistory.pastStates.length);
     undoQueue.current = [];
     redoQueue.current = [];
+    trackEvent("Restore to Default", "");
   });
 
   const canUndo = undoQueue.current.length > 0;

--- a/src/visx-visualization/heatmap/RowSelectionControls.tsx
+++ b/src/visx-visualization/heatmap/RowSelectionControls.tsx
@@ -1,6 +1,8 @@
 import { Tooltip } from "@mui/material";
 import React from "react";
+import { useRowConfig } from "../../contexts/AxisConfigContext";
 import { useRows } from "../../contexts/DataContext";
+import { useTrackEvent } from "../../contexts/EventTrackerProvider";
 import { useSelectedValues } from "../../contexts/ExpandedValuesContext";
 import { useYScale } from "../../contexts/ScaleContext";
 
@@ -11,6 +13,16 @@ export default function RowSelectionControls() {
   const toggleSelection = useSelectedValues((s) => s.toggleValue);
   const smallScale = scale.bandwidth() < 10;
   const rowsToRender = smallScale ? [...selectedValues] : rows;
+  const trackEvent = useTrackEvent();
+  const rowLabel = useRowConfig((s) => s.label);
+  const onChange = (row: string) => () => {
+    if (selectedValues.has(row)) {
+      trackEvent(`Expand ${rowLabel}`, row);
+    } else {
+      trackEvent(`Collapse ${rowLabel}`, row);
+    }
+    toggleSelection(row);
+  };
   return (
     <>
       {rowsToRender.map((row) => (
@@ -26,10 +38,10 @@ export default function RowSelectionControls() {
           <input
             type="checkbox"
             checked={selectedValues.has(row)}
-            onChange={() => toggleSelection(row)}
+            onChange={onChange(row)}
             style={{
-              width: Math.max(Math.floor(scale.bandwidth()), 16),
-              height: Math.max(Math.floor(scale.bandwidth()), 16),
+              width: Math.max(Math.min(Math.floor(scale.bandwidth()), 32), 16),
+              height: Math.max(Math.min(Math.floor(scale.bandwidth()), 32), 16),
               left: 0,
               top: scale(row),
               position: "absolute",

--- a/src/visx-visualization/heatmap/hooks.ts
+++ b/src/visx-visualization/heatmap/hooks.ts
@@ -1,13 +1,16 @@
 import { useCallback, useEffect } from "react";
 import { AxisConfig } from "../../contexts/AxisConfigContext";
+import { useTrackEvent } from "../../contexts/EventTrackerProvider";
 
 export function useOpenInNewTab(
   createHref: ((tick: string) => string) | undefined,
 ) {
+  const trackEvent = useTrackEvent();
   return useCallback(
     (tick: string) => {
       const href = createHref?.(tick);
       if (href) {
+        trackEvent("Open in new tab", tick, { href });
         window.open(href, "_blank");
       }
     },

--- a/src/visx-visualization/plot-controls.tsx/DisplayControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/DisplayControls.tsx
@@ -43,6 +43,7 @@ import {
   useRowConfig,
 } from "../../contexts/AxisConfigContext";
 import { useData } from "../../contexts/DataContext";
+import { useTrackEvent } from "../../contexts/EventTrackerProvider";
 import { useSelectedValues } from "../../contexts/ExpandedValuesContext";
 import InfoTooltip from "../InfoTooltip";
 import { usePlotControlsContext } from "./PlotControlsContext";
@@ -287,19 +288,35 @@ const useToggleVisibility = () => {
   const showItem = useData((s) =>
     section === "Column" ? s.restoreColumn : s.restoreRow,
   );
+  const columnLabel = useColumnConfig((s) => s.label);
+  const rowLabel = useRowConfig((s) => s.label);
+  const label = section === "Column" ? columnLabel : rowLabel;
+  const trackEvent = useTrackEvent();
   const handleChange = useEventCallback((e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.checked) {
       showItem(e.target.name);
+      trackEvent(`Show ${label}`, e.target.name);
     } else {
       hideItem(e.target.name);
+      trackEvent(`Hide ${label}`, e.target.name);
     }
   });
   return handleChange;
 };
 
 const useToggleExpansion = () => {
-  const toggleItem = useSelectedValues((s) => s.toggleValue);
+  const { toggleItem, selectedValues } = useSelectedValues((s) => ({
+    toggleItem: s.toggleValue,
+    selectedValues: s.selectedValues,
+  }));
+  const trackEvent = useTrackEvent();
+  const rowLabel = useRowConfig((s) => s.label);
   const handleChange = useEventCallback((e: ChangeEvent<HTMLInputElement>) => {
+    if (selectedValues.has(e.target.name)) {
+      trackEvent(`Collapse ${rowLabel}`, e.target.name);
+    } else {
+      trackEvent(`Expand ${rowLabel}`, e.target.name);
+    }
     toggleItem(e.target.name);
   });
   return handleChange;

--- a/src/visx-visualization/plot-controls.tsx/SortControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/SortControls.tsx
@@ -51,6 +51,7 @@ import {
   useAvailableRowSorts,
   useData,
 } from "../../contexts/DataContext";
+import { useTrackEvent } from "../../contexts/EventTrackerProvider";
 import {
   useFieldDisplayName,
   useSortableFields,
@@ -121,8 +122,10 @@ function useRevalidateSort() {
   const revalidateSort = useData((s) =>
     section === "Column" ? s.revalidateColumnSort : s.revalidateRowSort,
   );
+  const trackEvent = useTrackEvent();
   return useEventCallback(() => {
     revalidateSort();
+    trackEvent(`Revalidate ${section} Sort`, "");
   });
 }
 
@@ -154,6 +157,8 @@ export function SortControls() {
     setSorts: section === "Column" ? s.setColumnSortOrder : s.setRowSortOrder,
   }));
 
+  const trackEvent = useTrackEvent();
+
   const allowedSorts = useSortableFields(sorts.map((sort) => sort.key));
   const filteredSorts = sorts.filter((sort) => allowedSorts.includes(sort.key));
 
@@ -175,7 +180,10 @@ export function SortControls() {
       const oldIndex = sorts.findIndex((sort) => sort.key === active.id);
       const newIndex = sorts.findIndex((sort) => sort.key === over.id);
 
-      setSorts(arrayMove(sorts, oldIndex, newIndex));
+      const newSorts = arrayMove(sorts, oldIndex, newIndex);
+
+      setSorts(newSorts);
+      trackEvent("Update Sort Order", section, { newSorts });
     }
   });
 


### PR DESCRIPTION
This PR adds event tracking to the actions detailed in this spreadsheet: https://docs.google.com/spreadsheets/d/18hF0VDrepN58GiDX22_jJ6vsnfGwKE_GiL8hdD_Art4/edit?gid=1106330893#gid=1106330893

Namely,
- Change Graph Type (Violin/Bar)
- Change Control Orientation (Row/Column)
- Change Heatmap Theme
- Change App Theme
- Click Celltype Link
- Click Dataset Link
- Change Dataset Sort
- Change Celltype Sort
- Undo
- Redo
- Restore to Default
- Hide Cell Type
- Hide Dataset
- Restore Hidden Datasets
- Restore Hidden Cell Types
- Expand dataset
- Collapse dataset
- Collapse all datasets
- Revalidate sort
- Move row/column to start/end
- Sort Cell Types/Datasets