### PR TITLE
Nickakhmetov/fix-sort-regression

### DIFF
--- a/src/contexts/MetadataConfigContext.ts
+++ b/src/contexts/MetadataConfigContext.ts
@@ -52,6 +52,8 @@ export const [MetadataConfigProvider, useMetadataConfig] = createStoreContext<
 
 export const useFieldDisplayName = (field: string) =>
   useMetadataConfig().getFieldDisplayName(field);
+export const useGetFieldDisplayName = () =>
+  useMetadataConfig().getFieldDisplayName;
 export const useSortableFields = (fields: string[]) =>
   useMetadataConfig().getSortableFields(fields);
 export const useTooltipFields = (fields: string[]) =>

--- a/src/visx-visualization/plot-controls.tsx/SortControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/SortControls.tsx
@@ -53,7 +53,7 @@ import {
 } from "../../contexts/DataContext";
 import { useTrackEvent } from "../../contexts/EventTrackerProvider";
 import {
-  useFieldDisplayName,
+  useGetFieldDisplayName,
   useSortableFields,
 } from "../../contexts/MetadataConfigContext";
 import { usePlotControlsContext } from "./PlotControlsContext";
@@ -296,6 +296,7 @@ function SortItem({ sort, index }: { sort: SortOrder<string>; index: number }) {
   const remove = useEventCallback(() => {
     removeSort(sort.key);
   });
+  const getFieldDisplayName = useGetFieldDisplayName();
 
   return (
     <Stack key={sort.key} style={style} ref={setNodeRef}>
@@ -318,7 +319,7 @@ function SortItem({ sort, index }: { sort: SortOrder<string>; index: number }) {
         >
           {[sort.key, ...availableSorts].map((key) => (
             <MenuItem key={key} value={key}>
-              {useFieldDisplayName(key)}
+              {getFieldDisplayName(key)}
             </MenuItem>
           ))}
         </Select>


### PR DESCRIPTION
While introducing logic for custom field names, I accidentally included a call to the `useFieldDisplayName` hook inside of a `.map` call, which led to varying numbers of calls for the hook whenever sorts were added (which crashed the application.) This change fixes the issue by having the hook reference the mapping function instead of direclty calling it, allowing for a constant number of hook calls between renders.