### PR TITLE
NickAkhmetov/Fix violin rendering, add padding to top of control bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cellpop",
   "private": false,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "license": "MIT",
   "author": "Thomas Smits",
   "description": "A React component for visualizing cell populations in two-dimensional array data.",

--- a/src/visx-visualization/Controls.tsx
+++ b/src/visx-visualization/Controls.tsx
@@ -189,6 +189,7 @@ export default function Controls() {
       position="static"
       elevation={0}
       color={currentTheme === "dark" ? "default" : "default"}
+      sx={{ pt: 2 }}
     >
       <Stack direction="row" spacing={5} p={1}>
         <HeatmapThemeControl />


### PR DESCRIPTION
This PR resolves issues with 
- rendering violins when there are too few categories (the width of the violins caused them to overlap)
- top violins not reaching the bottom of that panel
- Cramped spacing in the controls app bar