### PR TITLE
Nickakhmetov/Bugfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cellpop",
   "private": false,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "author": "Thomas Smits",
   "description": "A React component for visualizing cell populations in two-dimensional array data.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cellpop",
   "private": false,
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "MIT",
   "author": "Thomas Smits",
   "description": "A React component for visualizing cell populations in two-dimensional array data.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cellpop",
   "private": false,
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "author": "Thomas Smits",
   "description": "A React component for visualizing cell populations in two-dimensional array data.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cellpop",
   "private": false,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "license": "MIT",
   "author": "Thomas Smits",
   "description": "A React component for visualizing cell populations in two-dimensional array data.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cellpop",
   "private": false,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "author": "Thomas Smits",
   "description": "A React component for visualizing cell populations in two-dimensional array data.",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cellpop",
   "private": false,
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "author": "Thomas Smits",
   "description": "A React component for visualizing cell populations in two-dimensional array data.",

--- a/src/CellPopComponent.tsx
+++ b/src/CellPopComponent.tsx
@@ -86,7 +86,11 @@ export const CellPop = withParentSize(
 
     return (
       <OuterContainerRefProvider value={outerContainerRef}>
-        <div onClick={handleClick} ref={outerContainerRef}>
+        <div
+          onClick={handleClick}
+          ref={outerContainerRef}
+          style={{ position: "relative", overflow: "hidden" }}
+        >
           <Providers
             data={data}
             dimensions={dimensions}

--- a/src/contexts/ColorScaleContext.tsx
+++ b/src/contexts/ColorScaleContext.tsx
@@ -36,7 +36,6 @@ export function ColorScaleProvider({ children }: PropsWithChildren) {
 
     const range = colorThresholds.map((_, idx) => idx / 255);
 
-    console.log({ range });
     const scale = scaleLinear<string>({
       range: range.map((t) => theme(t)),
       domain: range.map((r) => r * maxCount),

--- a/src/contexts/ScaleContext.tsx
+++ b/src/contexts/ScaleContext.tsx
@@ -65,8 +65,8 @@ export function ScaleProvider({ children }: PropsWithChildren) {
     if (
       // if no rows are selected/all rows are selected
       [0, rows.length].includes(expandedRows.size) ||
-      // if all selected rows are hidden
-      [...expandedRows].every((row) => !rows.includes(row))
+      // if there are very few rows
+      rows.length < 5
     ) {
       const scale = scaleBand<string>({
         range: [height, 0],

--- a/src/visx-visualization/Controls.tsx
+++ b/src/visx-visualization/Controls.tsx
@@ -158,7 +158,7 @@ function NormalizationControl() {
 
   return (
     <FormControl sx={{ maxWidth: 300 }}>
-      <InputLabel id={id}>Heatmap Normalization</InputLabel>
+      <InputLabel id={id} sx={(theme) => ({background: theme.palette.background.default})}>Heatmap&nbsp;Normalization</InputLabel>
       <Select
         labelId={id}
         id={`${id}-select`}

--- a/src/visx-visualization/Controls.tsx
+++ b/src/visx-visualization/Controls.tsx
@@ -152,13 +152,27 @@ function NormalizationControl() {
   });
 
   const id = useId();
+
+  const currentTheme = useSetTheme((state) => state.currentTheme);
+
   if (normalizationIsDisabled) {
     return null;
   }
 
   return (
     <FormControl sx={{ maxWidth: 300 }}>
-      <InputLabel id={id} sx={(theme) => ({background: theme.palette.background.default})}>Heatmap&nbsp;Normalization</InputLabel>
+      <InputLabel
+        id={id}
+        sx={(theme) => ({
+          background:
+            currentTheme === "dark"
+              ? theme.palette.background.default
+              : theme.palette.grey[100],
+          paddingRight: 2,
+        })}
+      >
+        Heatmap&nbsp;Normalization
+      </InputLabel>
       <Select
         labelId={id}
         id={`${id}-select`}
@@ -185,12 +199,7 @@ function NormalizationControl() {
 export default function Controls() {
   const currentTheme = useSetTheme((state) => state.currentTheme);
   return (
-    <AppBar
-      position="static"
-      elevation={0}
-      color={currentTheme === "dark" ? "default" : "default"}
-      sx={{ pt: 2 }}
-    >
+    <AppBar position="static" elevation={0} color={"default"} sx={{ pt: 2 }}>
       <Stack direction="row" spacing={5} p={1}>
         <HeatmapThemeControl />
         <NormalizationControl />

--- a/src/visx-visualization/heatmap/Heatmap.tsx
+++ b/src/visx-visualization/heatmap/Heatmap.tsx
@@ -53,8 +53,10 @@ function CanvasHeatmapRenderer() {
         // draw bar graph
         const max = rowMaxes[row];
 
+        const domain = normalization === "None" ? [0, max] : [0, 1];
+
         const inlineYScale = scaleLinear({
-          domain: [0, max],
+          domain,
           range: [0, cellHeight],
           nice: true,
         });

--- a/src/visx-visualization/heatmap/HeatmapYAxis.tsx
+++ b/src/visx-visualization/heatmap/HeatmapYAxis.tsx
@@ -9,7 +9,7 @@ import {
 import { scaleLinear } from "@visx/scale";
 import { Text } from "@visx/text";
 import React, { useId } from "react";
-import { AxisConfig, useRowConfig } from "../../contexts/AxisConfigContext";
+import { useRowConfig } from "../../contexts/AxisConfigContext";
 import {
   useData,
   useRowCounts,
@@ -120,6 +120,7 @@ export default function HeatmapYAxis() {
           fill: theme.palette.text.primary,
           pointerEvents: "none",
           className: "y-axis-label text",
+          dy: `${TICK_TEXT_SIZE * LEFT_MULTIPLIER}px`,
         }}
         hideTicks={selectedValues.size > 0}
       />

--- a/src/visx-visualization/heatmap/HeatmapYAxis.tsx
+++ b/src/visx-visualization/heatmap/HeatmapYAxis.tsx
@@ -72,17 +72,18 @@ export default function HeatmapYAxis() {
         left={tickLabelSize * LEFT_MULTIPLIER}
         stroke={theme.palette.text.primary}
         tickStroke={theme.palette.text.primary}
-        tickComponent={
-          selectedValues.size > 0
-            ? (props) =>
-                ExpandedRowTick({
-                  ...props,
-                  axisConfig,
-                  openInNewTab,
-                  tickTitle,
-                  tickLabelStyle,
-                })
-            : undefined
+        tickComponent={(tickLabelProps: TickRendererProps) =>
+          selectedValues.has(tickLabelProps?.formattedValue as string) ? (
+            <ExpandedRowTick {...tickLabelProps} />
+          ) : (
+            <Text
+              {...tickLabelProps}
+              // @ts-expect-error Visx types are slightly incorrect
+              x={(tickLabelProps?.to?.x ?? 0) - tickLabelProps.fontSize}
+            >
+              {tickLabelProps?.formattedValue}
+            </Text>
+          )
         }
         tickLabelProps={(t) =>
           ({
@@ -129,18 +130,16 @@ function ExpandedRowTick({
   x,
   y,
   formattedValue: row,
-  axisConfig,
-  openInNewTab,
-  tickTitle,
-  tickLabelStyle,
   ...tickLabelProps
-}: TickRendererProps & {
-  axisConfig: AxisConfig;
-} & ReturnType<typeof useHeatmapAxis>) {
+}: TickRendererProps) {
   const { expandedSize } = useYScale();
   const selectedValues = useSelectedValues((s) => s.selectedValues);
-  const { flipAxisPosition } = axisConfig;
   const rowMaxes = useRowMaxes();
+  const axisConfig = useRowConfig();
+  const { flipAxisPosition } = axisConfig;
+
+  const { openInNewTab, tickTitle, tickLabelStyle } =
+    useHeatmapAxis(axisConfig);
 
   const panelSize = usePanelDimensions(
     flipAxisPosition ? "left_middle" : "right_middle",

--- a/src/visx-visualization/heatmap/HeatmapYAxis.tsx
+++ b/src/visx-visualization/heatmap/HeatmapYAxis.tsx
@@ -132,10 +132,11 @@ function ExpandedRowTick({
   formattedValue: row,
   ...tickLabelProps
 }: TickRendererProps) {
-  const { expandedSize } = useYScale();
+  const { expandedSize, nonExpandedSize } = useYScale();
   const selectedValues = useSelectedValues((s) => s.selectedValues);
   const rowMaxes = useRowMaxes();
   const axisConfig = useRowConfig();
+  const rows = useRows();
   const { flipAxisPosition } = axisConfig;
 
   const { openInNewTab, tickTitle, tickLabelStyle } =
@@ -154,14 +155,25 @@ function ExpandedRowTick({
     // Use the tick label as the axis label
     const Axis = flipAxisPosition ? AxisLeft : AxisRight;
     const max = rowMaxes[row!];
+    const range =
+      expandedSize > nonExpandedSize
+        ? [EXPANDED_ROW_PADDING, expandedSize - EXPANDED_ROW_PADDING / 2]
+        : [EXPANDED_ROW_PADDING, nonExpandedSize];
+
     const yScale = scaleLinear({
       domain: [max, 0],
-      range: [EXPANDED_ROW_PADDING, expandedSize - EXPANDED_ROW_PADDING],
+      range: range,
       nice: true,
     });
+
+    const top =
+      expandedSize > nonExpandedSize
+        ? y - nonExpandedSize / 2 - EXPANDED_ROW_PADDING * 2
+        : y - expandedSize / 2;
+
     return (
       <Axis
-        top={y - EXPANDED_ROW_PADDING * 2}
+        top={top}
         orientation="left"
         left={panelSize.width - tickLabelSize * LEFT_MULTIPLIER}
         scale={yScale}

--- a/src/visx-visualization/heatmap/HeatmapYAxis.tsx
+++ b/src/visx-visualization/heatmap/HeatmapYAxis.tsx
@@ -18,6 +18,7 @@ import {
 } from "../../contexts/DataContext";
 import { usePanelDimensions } from "../../contexts/DimensionsContext";
 import { useSelectedValues } from "../../contexts/ExpandedValuesContext";
+import { useNormalization } from "../../contexts/NormalizationContext";
 import { EXPANDED_ROW_PADDING, useYScale } from "../../contexts/ScaleContext";
 import { useSetTooltipData } from "../../contexts/TooltipDataContext";
 import { LEFT_MULTIPLIER } from "../side-graphs/constants";
@@ -160,9 +161,15 @@ function ExpandedRowTick({
         ? [EXPANDED_ROW_PADDING, expandedSize - EXPANDED_ROW_PADDING / 2]
         : [EXPANDED_ROW_PADDING, nonExpandedSize];
 
+    const normalizationIsNotNone = useNormalization(
+      (s) => s.normalization !== "None",
+    );
+
+    const domain = normalizationIsNotNone ? [1, 0] : [max, 0];
+
     const yScale = scaleLinear({
-      domain: [max, 0],
-      range: range,
+      domain,
+      range,
       nice: true,
     });
 
@@ -179,6 +186,9 @@ function ExpandedRowTick({
         scale={yScale}
         label={row}
         labelOffset={expandedSize / 2}
+        tickFormat={
+          normalizationIsNotNone ? (v) => `${(v as number) * 100}%` : undefined
+        }
         tickLabelProps={{
           fill: theme.palette.text.primary,
           style: tickLabelStyle,

--- a/src/visx-visualization/heatmap/MetadataValueBar.tsx
+++ b/src/visx-visualization/heatmap/MetadataValueBar.tsx
@@ -135,7 +135,7 @@ export default function MetadataValueBar({
   const cellWidth = x.bandwidth();
 
   const axisLabelX = axis === "X" ? width / 2 : width / 3;
-  const axisLabelY = axis === "X" ? height / 3 : height / 2;
+  const axisLabelY = axis === "X" ? height - 16 : height / 2;
 
   const onMouseMove = useCallback((e: React.MouseEvent<SVGRectElement>) => {
     const target = e.target as SVGRectElement;

--- a/src/visx-visualization/plot-controls.tsx/DisplayControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/DisplayControls.tsx
@@ -292,11 +292,16 @@ const useToggleVisibility = () => {
   const rowLabel = useRowConfig((s) => s.label);
   const label = section === "Column" ? columnLabel : rowLabel;
   const trackEvent = useTrackEvent();
+  const selectedValues = useSelectedValues((s) => s.selectedValues);
+  const deselectValue = useSelectedValues((s) => s.deselectValue);
   const handleChange = useEventCallback((e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.checked) {
       showItem(e.target.name);
       trackEvent(`Show ${label}`, e.target.name);
     } else {
+      if (section === "Row" && selectedValues.has(e.target.name)) {
+        deselectValue(e.target.name);
+      }
       hideItem(e.target.name);
       trackEvent(`Hide ${label}`, e.target.name);
     }
@@ -309,13 +314,20 @@ const useToggleExpansion = () => {
     toggleItem: s.toggleValue,
     selectedValues: s.selectedValues,
   }));
+  const showItem = useData((s) => s.restoreRow);
+  const removedRows = useData((s) => s.removedRows);
   const trackEvent = useTrackEvent();
   const rowLabel = useRowConfig((s) => s.label);
   const handleChange = useEventCallback((e: ChangeEvent<HTMLInputElement>) => {
-    if (selectedValues.has(e.target.name)) {
-      trackEvent(`Collapse ${rowLabel}`, e.target.name);
+    const row = e.target.name;
+    if (selectedValues.has(row)) {
+      trackEvent(`Collapse ${rowLabel}`, row);
     } else {
-      trackEvent(`Expand ${rowLabel}`, e.target.name);
+      const rowIsHidden = removedRows.has(row);
+      if (rowIsHidden) {
+        showItem(e.target.name);
+      }
+      trackEvent(`Expand ${rowLabel}`, row);
     }
     toggleItem(e.target.name);
   });

--- a/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
@@ -122,7 +122,7 @@ function PlotControls({ onClose }: PlotControlsProps) {
   );
 }
 
-const StyledDrawer = styled(Drawer)(({ theme }) => ({
+const StyledDrawer = styled(Drawer)(() => ({
   position: "absolute",
   top: 0,
   zIndex: 1300,
@@ -133,9 +133,6 @@ export function PlotControlsButton() {
   const [showDrawer, setShowDrawer] = useState(false);
   const closeDrawer = useEventCallback(() => setShowDrawer(false));
   const openDrawer = useEventCallback(() => setShowDrawer(true));
-  const [slideDirection, setSlideDirection] = useState<"left" | "right">(
-    "right",
-  );
 
   return (
     <>
@@ -152,11 +149,9 @@ export function PlotControlsButton() {
         open={showDrawer}
         onClose={closeDrawer}
         anchor="right"
-        SlideProps={{
-          container: parentRef.current,
-          direction: slideDirection,
-          onEntered: () => setSlideDirection("left"),
-          onExited: () => setSlideDirection("right"),
+        transitionDuration={{
+          enter: 0,
+          exit: 300,
         }}
         ModalProps={{
           sx: {

--- a/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
@@ -125,7 +125,7 @@ function PlotControls({ onClose }: PlotControlsProps) {
 const StyledDrawer = styled(Drawer)(() => ({
   position: "absolute",
   top: 0,
-  zIndex: 1300,
+  zIndex: 1099,
 }));
 
 export function PlotControlsButton() {

--- a/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
@@ -140,7 +140,6 @@ export function PlotControlsButton() {
         Plot Controls
       </Button>
       <Drawer
-        container={parentRef.current}
         open={showDrawer}
         onClose={closeDrawer}
         anchor="right"

--- a/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
@@ -8,6 +8,7 @@ import {
   Divider,
   IconButton,
   Stack,
+  styled,
   Tab,
   Tabs,
   Typography,
@@ -121,13 +122,20 @@ function PlotControls({ onClose }: PlotControlsProps) {
   );
 }
 
+const StyledDrawer = styled(Drawer)(({ theme }) => ({
+  position: "absolute",
+  top: 0,
+  zIndex: 1300,
+}));
+
 export function PlotControlsButton() {
   const parentRef = useOuterContainerRef();
   const [showDrawer, setShowDrawer] = useState(false);
   const closeDrawer = useEventCallback(() => setShowDrawer(false));
   const openDrawer = useEventCallback(() => setShowDrawer(true));
-  const parentBoundingBox = parentRef.current?.getBoundingClientRect();
-  const windowBoundingBox = window.document.body.getBoundingClientRect();
+  const [slideDirection, setSlideDirection] = useState<"left" | "right">(
+    "right",
+  );
 
   return (
     <>
@@ -139,28 +147,24 @@ export function PlotControlsButton() {
       >
         Plot Controls
       </Button>
-      <Drawer
+      <StyledDrawer
+        container={parentRef.current}
         open={showDrawer}
         onClose={closeDrawer}
         anchor="right"
         SlideProps={{
           container: parentRef.current,
+          direction: slideDirection,
+          onEntered: () => setSlideDirection("left"),
+          onExited: () => setSlideDirection("right"),
         }}
         ModalProps={{
           sx: {
-            top: parentBoundingBox?.top,
-            height: parentBoundingBox?.height,
-            right: windowBoundingBox.right - (parentBoundingBox?.right ?? 0),
+            position: "absolute",
           },
         }}
         slotProps={{
           backdrop: {
-            sx: {
-              top: parentBoundingBox?.top,
-              height: parentBoundingBox?.height,
-              left: parentBoundingBox?.left,
-              width: parentBoundingBox?.width,
-            },
             invisible: true,
           },
         }}
@@ -170,15 +174,15 @@ export function PlotControlsButton() {
               xs: "100%",
               md: 450,
             },
-            top: parentBoundingBox?.top,
-            height: parentBoundingBox?.height,
-            right: windowBoundingBox.right - (parentBoundingBox?.right ?? 0),
+            position: "absolute",
+            top: 0,
+            right: 0,
             scrollBehavior: "smooth",
           },
         }}
       >
         <PlotControls onClose={closeDrawer} />
-      </Drawer>
+      </StyledDrawer>
     </>
   );
 }


### PR DESCRIPTION
This PR resolves a few issues that became apparent during testing on the portal:
* [The heatmap normalization label now has a background to ensure the outlined input doesn't overlap with it](https://hms-dbmi.atlassian.net/browse/CAT-1125)
* Visualization no longer breaks when re-enabling visibility for a hidden dataset while there is an expanded dataset
* Expanded rows no longer overlap when there are too few data point entries