### PR TITLE
Add filters

### DIFF
--- a/src/CellPopComponent.tsx
+++ b/src/CellPopComponent.tsx
@@ -24,6 +24,7 @@ interface CellPopConfig {
   initialProportions?: [GridSizeTuple, GridSizeTuple];
   fieldDisplayNames?: Record<string, string>;
   sortableFields?: string[];
+  filterableFields?: string[];
   tooltipFields?: string[];
   trackEvent?: (
     event: string,
@@ -55,6 +56,7 @@ export const CellPop = withParentSize(
     initialProportions,
     fieldDisplayNames,
     sortableFields,
+    filterableFields,
     tooltipFields,
     trackEvent,
   }: CellPopProps) => {
@@ -102,6 +104,7 @@ export const CellPop = withParentSize(
             initialProportions={initialProportions}
             fieldDisplayNames={fieldDisplayNames}
             sortableFields={sortableFields}
+            filterableFields={filterableFields}
             tooltipFields={tooltipFields}
             trackEvent={trackEvent}
           >

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -844,6 +844,23 @@ export const useAvailableColumnSorts = () => {
   );
 };
 
+export function sortFilterValues(values: (string | number | boolean)[]) {
+  const valuesCopy = [...values];
+  valuesCopy.sort((a, b) => {
+    if (typeof a === "boolean") {
+      a = a ? 1 : 0;
+    }
+    if (typeof b === "boolean") {
+      b = b ? 1 : 0;
+    }
+    if (typeof a === "number" && typeof b === "number") {
+      return a - b;
+    }
+    return String(a).localeCompare(String(b));
+  });
+  return valuesCopy;
+}
+
 export const useAvailableRowFilters = () => {
   const rowFilterKeys = useData(getRowFilterKeys);
   const currentRowFilters = useData((s) => s.rowFilters);
@@ -859,7 +876,7 @@ export const useAllRowSubFilters = (key: string) => {
   const rowFilterKeys = useData(getRowFilterKeys);
 
   const entry = rowFilterKeys.find(([k]) => k === key);
-  return entry ? Array.from(entry[1]) : [];
+  return entry ? sortFilterValues(Array.from(entry[1])) : [];
 };
 
 export const useAvailableColumnFilters = () => {
@@ -877,7 +894,7 @@ export const useAllColumnSubFilters = (key: string) => {
   const columnFilterKeys = useData(getColumnFilterKeys);
 
   const entry = columnFilterKeys.find(([k]) => k === key);
-  return entry ? Array.from(entry[1]) : [];
+  return entry ? sortFilterValues(Array.from(entry[1])) : [];
 };
 
 export const useHighestColumnCount = () => {

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -291,8 +291,8 @@ const applyFilters = (
       if (filter.values.length === 0) continue;
 
       const itemMetadata = metadata?.[item];
-      const itemValue = itemMetadata?.[filter.key];
-      if (itemValue === undefined || filter.values.includes(itemValue)) {
+      let itemValue = itemMetadata?.[filter.key] ?? "undefined";
+      if (filter.values.includes(itemValue)) {
         discarded.push(item);
         break;
       }
@@ -516,13 +516,13 @@ const createDataContextStore = ({ initialData }: DataContextProps) =>
       addRowFilter: (key: string) => {
         set((state) => {
           const rowFilters = [...state.rowFilters, { key, values: [] }];
-          return { rowFilters }; //rowFilterInvalidated?
+          return { rowFilters };
         });
       },
       addColumnFilter: (key: string) => {
         set((state) => {
           const columnFilters = [...state.columnFilters, { key, values: [] }];
-          return { columnFilters }; //columnFilterInvalidated?
+          return { columnFilters };
         });
       },
       editRowSubFilters: (key: string, values: (string | number | boolean)[]) => {
@@ -692,7 +692,7 @@ const getMetadataObject = (
     (acc, curr) => {
       Object.entries(curr).forEach(([key, value]) => {
         if (!acc[key]) acc[key] = new Set();
-        acc[key].add(value);
+        acc[key].add(value === undefined ? "undefined" : value);
       });
       return acc;
     },

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -760,30 +760,12 @@ export const useRowMetadataKeys = () => {
   return useMetadataKeys("row");
 };
 
-export const useRowSorts: () => SortOrder<string>[] = () => {
-  const keys = useRowSortKeys();
-  return useMemo(() => {
-    return ["asc", "desc"].flatMap((direction) =>
-      keys.map((key) => ({ key, direction }) as SortOrder<string>),
-    );
-  }, [keys]);
-};
-
 export const useColumnMetadataKeys = () => {
   return useMetadataKeys("column");
 };
 
 export const useColumnSortKeys = () => {
   return useSortKeys("column");
-};
-
-export const useColumnSorts: () => SortOrder<string>[] = () => {
-  const keys = useColumnSortKeys();
-  return useMemo(() => {
-    return ["asc", "desc"].flatMap((direction) =>
-      keys.map((key) => ({ key, direction }) as SortOrder<string>),
-    );
-  }, [keys]);
 };
 
 export const useDataMap = () => {

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -162,27 +162,11 @@ interface DataContextActions {
   /**
    * 
    */
-  addRowSubFilter: (key: string, value: string | number | boolean) => void;
-  /**
-   * 
-   */
-  addColumnSubFilter: (key: string, value: string | number | boolean) => void;
-  /**
-   * 
-   */
   editRowFilter: (index: number, newKey: string) => void;
   /**
    * 
    */
   editColumnFilter: (index: number, newKey: string) => void;
-  /**
-   * 
-   */
-  removeRowSubFilter: (key: string, value: string | number | boolean) => void;
-  /**
-   * 
-   */
-  removeColumnSubFilter: (key: string, value: string | number | boolean) => void;
   /**
    * 
    */
@@ -565,34 +549,6 @@ const createDataContextStore = ({ initialData }: DataContextProps) =>
           return { columnFilters, filteredColumns };
         });
       },
-      addRowSubFilter: (key: string, value: string | number | boolean) => {
-        set((state) => {
-          const rowFilters = state.rowFilters.map((filter) => {
-            if (filter.key === key) {
-              const values = new Set(filter.values);
-              values.add(value);
-              return { key, values: Array.from(values) };
-            }
-            return filter;
-          });
-          const filteredRows = new Set(applyFilters(state.data.rowNames, rowFilters, state, true));
-          return { rowFilters, filteredRows };
-        });
-      },
-      addColumnSubFilter: (key: string, value: string | number | boolean) => {
-        set((state) => {
-          const columnFilters = state.columnFilters.map((filter) => {
-            if (filter.key === key) {
-              const values = new Set(filter.values);
-              values.add(value);
-              return { key, values: Array.from(values) };
-            }
-            return filter;
-          });
-          const filteredColumns = new Set(applyFilters(state.data.colNames, columnFilters, state, false));
-          return { columnFilters, filteredColumns };
-        });
-      },
       editRowFilter: (index: number, newKey: string) => {
         set((state) => {
           const rowFilters = [...state.rowFilters];
@@ -605,34 +561,6 @@ const createDataContextStore = ({ initialData }: DataContextProps) =>
         set((state) => {
           const columnFilters = [...state.columnFilters];
           columnFilters[index] = {key: newKey, values: []};
-          const filteredColumns = new Set(applyFilters(state.data.colNames, columnFilters, state, false));
-          return { columnFilters, filteredColumns };
-        });
-      },
-      removeRowSubFilter: (key: string, value: string | number | boolean) => {
-        set((state) => {
-          const rowFilters = state.rowFilters.map((filter) => {
-            if (filter.key === key) {
-              const values = new Set(filter.values);
-              values.delete(value);
-              return { key, values: Array.from(values) };
-            }
-            return filter;
-          });
-          const filteredRows = new Set(applyFilters(state.data.rowNames, rowFilters, state, true));
-          return { rowFilters, filteredRows };
-        });
-      },
-      removeColumnSubFilter: (key: string, value: string | number | boolean) => {
-        set((state) => {
-          const columnFilters = state.columnFilters.map((filter) => {
-            if (filter.key === key) {
-              const values = new Set(filter.values);
-              values.delete(value);
-              return { key, values: Array.from(values) };
-            }
-            return filter;
-          });
           const filteredColumns = new Set(applyFilters(state.data.colNames, columnFilters, state, false));
           return { columnFilters, filteredColumns };
         });

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -280,15 +280,14 @@ const applyFilters = (
   const metadata = row ? state.data.metadata.rows : state.data.metadata.cols;
   let discarded = [] as string[];
 
-  if (filters.length === 0) {
+  const activeFilters = filters.filter(f => f.values.length !== 0)
+  
+  if (activeFilters.length === 0) {
     return discarded;
   }
 
-  const arrayCopy = [...array];
-
-  for (const item of arrayCopy) {
-    for (const filter of filters) {
-      if (filter.values.length === 0) continue;
+  for (const item of array) {
+    for (const filter of activeFilters) {
 
       const itemMetadata = metadata?.[item];
       let itemValue = itemMetadata?.[filter.key] ?? "undefined";

--- a/src/contexts/MetadataConfigContext.ts
+++ b/src/contexts/MetadataConfigContext.ts
@@ -4,12 +4,14 @@ import { createStoreContext } from "../utils/zustand";
 interface MetadataConfigContextProps {
   fieldDisplayNames?: Record<string, string>;
   sortableFields?: string[];
+  filterableFields?: string[];
   tooltipFields?: string[];
 }
 
 interface MetadataConfigContextActions {
   getFieldDisplayName: (field: string) => string;
   getSortableFields: (fields: string[]) => string[];
+  getFilterableFields: (fields: string[]) => string[];
   getTooltipFields: (fields: string[]) => string[];
 }
 
@@ -18,14 +20,18 @@ interface MetadataConfigContext
     MetadataConfigContextActions {}
 
 const capitalizeAndReplaceUnderscores = (str: string) =>
-  str
-    .split("_")
-    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
-    .join(" ");
+  {
+    return str
+      .split("_")
+      .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+      .join(" ");
+  }
+  
 
 const createMetadataConfigStore = ({
   fieldDisplayNames,
   sortableFields,
+  filterableFields,
   tooltipFields,
 }: MetadataConfigContextProps) => {
   return createStore<MetadataConfigContext>()(() => ({
@@ -37,6 +43,10 @@ const createMetadataConfigStore = ({
     getSortableFields: (fields: string[]) =>
       sortableFields
         ? fields.filter((field) => sortableFields.includes(field))
+        : fields,
+    getFilterableFields: (fields: string[]) =>
+      filterableFields
+        ? fields.filter((field) => filterableFields.includes(field))
         : fields,
     getTooltipFields: (fields: string[]) =>
       tooltipFields
@@ -56,5 +66,7 @@ export const useGetFieldDisplayName = () =>
   useMetadataConfig().getFieldDisplayName;
 export const useSortableFields = (fields: string[]) =>
   useMetadataConfig().getSortableFields(fields);
+export const useFilterableFields = (fields: string[]) =>
+  useMetadataConfig().getFilterableFields(fields);
 export const useTooltipFields = (fields: string[]) =>
   useMetadataConfig().getTooltipFields(fields);

--- a/src/contexts/Providers.tsx
+++ b/src/contexts/Providers.tsx
@@ -43,6 +43,7 @@ interface CellPopConfigProps extends PropsWithChildren {
   initialProportions?: [GridSizeTuple, GridSizeTuple];
   fieldDisplayNames?: Record<string, string>;
   sortableFields?: string[];
+  filterableFields?: string[];
   tooltipFields?: string[];
   trackEvent?: (
     event: string,
@@ -67,6 +68,7 @@ export function Providers({
   initialProportions = [INITIAL_PROPORTIONS, INITIAL_PROPORTIONS],
   fieldDisplayNames,
   sortableFields,
+  filterableFields,
   tooltipFields,
   trackEvent,
 }: CellPopConfigProps) {
@@ -95,6 +97,7 @@ export function Providers({
                                 <MetadataConfigProvider
                                   fieldDisplayNames={fieldDisplayNames}
                                   sortableFields={sortableFields}
+                                  filterableFields={filterableFields}
                                   tooltipFields={tooltipFields}
                                 >
                                   {children}

--- a/src/visx-visualization/heatmap/ContextMenu.tsx
+++ b/src/visx-visualization/heatmap/ContextMenu.tsx
@@ -8,14 +8,14 @@ import {
 import {
   useAllColumnSubFilters,
   useAllRowSubFilters,
-  useColumnSorts,
+  useColumnSortKeys,
   useData,
   useMetadataKeys,
   useMoveColumnToEnd,
   useMoveColumnToStart,
   useMoveRowToEnd,
   useMoveRowToStart,
-  useRowSorts,
+  useRowSortKeys,
 } from "../../contexts/DataContext";
 import { useTrackEvent } from "../../contexts/EventTrackerProvider";
 import { useSelectedValues } from "../../contexts/ExpandedValuesContext";
@@ -135,6 +135,55 @@ const RestoreHiddenColumns = () => {
     </ContextMenuItem>
   );
 };
+const ResetSorts = () => {
+  const { setRowSortOrder, setColumnSortOrder, rowSortOrder, columnSortOrder } =
+    useData((s) => ({
+      setRowSortOrder: s.setRowSortOrder,
+      setColumnSortOrder: s.setColumnSortOrder,
+      rowSortOrder: s.rowSortOrder,
+      columnSortOrder: s.columnSortOrder,
+    }));
+
+  const trackEvent = useTrackEvent();
+
+  const handleClick = useEventCallback(() => {
+    setRowSortOrder([]);
+    setColumnSortOrder([]);
+    trackEvent("Reset Sorts", "");
+  });
+
+  if (!rowSortOrder.length && !columnSortOrder.length) {
+    return null;
+  }
+
+  return <ContextMenuItem onClick={handleClick}>Reset Sorts</ContextMenuItem>;
+};
+
+const ResetFilters = () => {
+  const { setRowFilters, setColumnFilters, rowFilters, columnFilters } = useData(
+    (s) => ({
+      setRowFilters: s.setRowFilters,
+      setColumnFilters: s.setColumnFilters,
+      rowFilters: s.rowFilters,
+      columnFilters: s.columnFilters,
+    })
+  );
+
+  const trackEvent = useTrackEvent();
+
+  const handleClick = useEventCallback(() => {
+    setRowFilters([]);
+    setColumnFilters([]);
+    trackEvent("Reset Filters", "");
+  });
+
+  if (!rowFilters.length && !columnFilters.length) {
+    return null;
+  }
+
+  return <ContextMenuItem onClick={handleClick}>Reset Filters</ContextMenuItem>;
+};
+
 
 const ExpandRow = () => {
   const { tooltipData } = useTooltipData();
@@ -246,8 +295,8 @@ const SortDimension = ({ dimension }: { dimension: "row" | "column" }) => {
       rowSortOrder: s.rowSortOrder,
     };
   });
-  const rowSortOrders = useRowSorts();
-  const colSortOrders = useColumnSorts();
+  const rowSortOrders = useRowSortKeys();
+  const colSortOrders = useColumnSortKeys();
 
   const sort = dimension === "row" ? sortRows : sortColumns;
   const sortOrders = dimension === "row" ? rowSortOrders : colSortOrders;
@@ -258,6 +307,24 @@ const SortDimension = ({ dimension }: { dimension: "row" | "column" }) => {
 
   const trackEvent = useTrackEvent();
 
+  const getFieldDisplayName = useGetFieldDisplayName();
+
+  const handleSelect = (order: string, direction: "asc" | "desc") => {
+    const sortExists = currentSortOrder.some((s) => s.key === order && s.direction === direction);
+    const sortOppositeExists = currentSortOrder.some((s) => s.key === order && s.direction !== direction);
+
+    if (sortExists) {
+      sort(currentSortOrder.filter((s) => !(s.key === order && s.direction === direction)));
+      trackEvent(`Sort ${label}s`, `Removed ${order} ${direction}`);
+    } else if (sortOppositeExists) {
+      sort(currentSortOrder.map((s) => s.key === order ? { key: order, direction } : s));
+      trackEvent(`Sort ${label}s`, `Changed Direction ${order} ${direction}`);
+    } else {
+      sort([...currentSortOrder, { key: order, direction }]);
+      trackEvent(`Sort ${label}s`, `Added ${order} ${direction}`);
+    }
+  }
+
   return (
     <ContextMenu.Sub>
       <ContextMenuSubTrigger>
@@ -266,18 +333,32 @@ const SortDimension = ({ dimension }: { dimension: "row" | "column" }) => {
       <ContextMenu.Portal>
         <ContextMenuSubContent sideOffset={2} alignOffset={-5}>
           {sortOrders.map((order) => (
-            <ContextMenuItem
-              key={order.key + order.direction}
-              onClick={() => {
-                sort([order]);
-                trackEvent(`Sort ${label}s`, `${order.key} ${order.direction}`);
-              }}
-            >
-              {order.key.charAt(0).toUpperCase()}
-              {order.key.slice(1).replace("_", " ")}{" "}
-              {order.direction === "asc" ? "Ascending" : "Descending"}
-              {currentSortOrder.includes(order) && <RightSlot>✓</RightSlot>}
-            </ContextMenuItem>
+            <ContextMenu.Sub key={order}>
+              <ContextMenuSubTrigger>
+                {getFieldDisplayName(order)}
+              </ContextMenuSubTrigger>
+              <ContextMenu.Portal>
+                <ContextMenuSubContent sideOffset={2} alignOffset={-5}>
+                  {(["asc", "desc"] as const).map((direction) => (
+                    <ContextMenuItem 
+                      key={order + direction}
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        handleSelect(order, direction)
+                      }}
+                    >
+                      <ContextMenu.CheckboxItem 
+                        // checked={currentSortOrder.includes({key: order, direction: direction})}
+                        checked={currentSortOrder.some((s) => s.key === order && s.direction === direction)}
+                      >
+                        <ContextMenu.ItemIndicator>✓</ContextMenu.ItemIndicator>
+                      </ContextMenu.CheckboxItem>
+                      {direction === "asc" ? "Ascending" : "Descending"}
+                    </ContextMenuItem>
+                  ))}
+                </ContextMenuSubContent>
+              </ContextMenu.Portal>
+            </ContextMenu.Sub>
           ))}
         </ContextMenuSubContent>
       </ContextMenu.Portal>
@@ -319,7 +400,6 @@ const FilterDimension = ({ dimension }: { dimension: "row" | "column" }) => {
   const trackEvent = useTrackEvent();
 
   const handleSelect = (filter: string, subfilter: string | number | boolean) => {
-    console.log("filter", filter, subfilter)
     if (!currentFilterKeys.includes(filter)) {
       addFilter(filter);
       editSubFilters(filter, [subfilter]);
@@ -401,11 +481,9 @@ const ContextMenuComponent = () => {
       <ContextMenuContent>
         <ContextMenuLabel>Global Actions</ContextMenuLabel>
         <RestoreHiddenRows />
-        <SortDimension dimension="row" />
-        <FilterDimension dimension="row" />
         <RestoreHiddenColumns />
-        <SortDimension dimension="column" />
-        <FilterDimension dimension="column" />
+        <ResetSorts />
+        <ResetFilters />
         {hasRow && (
           <>
             <ContextMenuSeparator />
@@ -415,6 +493,8 @@ const ContextMenuComponent = () => {
             <MoveToEnd dimension="row" />
             <ExpandRow />
             <CollapseRows />
+            <SortDimension dimension="row" />
+            <FilterDimension dimension="row" />
           </>
         )}
         {hasColumn && (
@@ -424,6 +504,8 @@ const ContextMenuComponent = () => {
             <HideColumn />
             <MoveToStart dimension="column" />
             <MoveToEnd dimension="column" />
+            <SortDimension dimension="column" />
+            <FilterDimension dimension="column" />
           </>
         )}
       </ContextMenuContent>

--- a/src/visx-visualization/plot-controls.tsx/FilterControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/FilterControls.tsx
@@ -1,0 +1,366 @@
+import {
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  Add,
+  ArrowDownwardRounded,
+  ArrowUpwardRounded,
+  Close,
+  DragHandle,
+  ExpandMoreRounded,
+  Restore,
+  Sort,
+} from "@mui/icons-material";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Button,
+  FormControl,
+  FormControlLabel,
+  Icon,
+  IconButton,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Select,
+  SelectChangeEvent,
+  Stack,
+  Typography,
+  useEventCallback,
+} from "@mui/material";
+import React from "react";
+import {
+  SortOrder,
+  useAvailableColumnSorts,
+  useAvailableRowSorts,
+  useData,
+} from "../../contexts/DataContext";
+import { useTrackEvent } from "../../contexts/EventTrackerProvider";
+import {
+  useGetFieldDisplayName,
+  useSortableFields,
+} from "../../contexts/MetadataConfigContext";
+import { usePlotControlsContext } from "./PlotControlsContext";
+import { LeftAlignedButton } from "./style";
+
+function useAvailableSorts() {
+  const section = usePlotControlsContext();
+  const columns = useAvailableColumnSorts();
+  const rows = useAvailableRowSorts();
+  return section === "Column" ? columns : rows;
+}
+
+function AddSort() {
+  const section = usePlotControlsContext();
+
+  const availableSorts = useAvailableSorts();
+  const addSort = useData((s) =>
+    section === "Column" ? s.addColumnSortOrder : s.addRowSortOrder,
+  );
+  const sortIsInvalidated = useSortIsInvalidated();
+  const disabled = availableSorts.length === 0;
+  const onClick = useEventCallback(() => {
+    if (availableSorts.length > 0) {
+      addSort({ key: availableSorts[0], direction: "asc" });
+    }
+  });
+  if (sortIsInvalidated) {
+    return null;
+  }
+  return (
+    <LeftAlignedButton
+      variant="text"
+      startIcon={<Add />}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      Add Sort
+    </LeftAlignedButton>
+  );
+}
+
+function useResetSorts() {
+  const section = usePlotControlsContext();
+  const resetSorts = useData((s) =>
+    section === "Column" ? s.clearColumnSortOrder : s.clearRowSortOrder,
+  );
+  const currentSorts = useData((s) =>
+    section === "Column" ? s.columnSortOrder : s.rowSortOrder,
+  );
+  const disabled = currentSorts.length === 0;
+  const onClick = useEventCallback(() => {
+    resetSorts();
+  });
+  return { disabled, onClick };
+}
+
+function useSortIsInvalidated() {
+  const section = usePlotControlsContext();
+  return useData((s) =>
+    section === "Column" ? s.columnSortInvalidated : s.rowSortInvalidated,
+  );
+}
+
+function useRevalidateSort() {
+  const section = usePlotControlsContext();
+  const revalidateSort = useData((s) =>
+    section === "Column" ? s.revalidateColumnSort : s.revalidateRowSort,
+  );
+  const trackEvent = useTrackEvent();
+  return useEventCallback(() => {
+    revalidateSort();
+    trackEvent(`Revalidate ${section} Sort`, "");
+  });
+}
+
+function InvalidationAlert() {
+  const sortIsInvalidated = useSortIsInvalidated();
+  const revalidateSort = useRevalidateSort();
+  if (!sortIsInvalidated) return null;
+  return (
+    <Alert
+      severity="info"
+      variant="outlined"
+      sx={{ alignItems: "center", mb: 2 }}
+      action={
+        <Button color="inherit" size="small" onClick={revalidateSort}>
+          Restore Sorts
+        </Button>
+      }
+    >
+      The data order has been manually changed and the sort order is no longer
+      valid. Sorting is currently disabled.
+    </Alert>
+  );
+}
+
+export function SortControls() {
+  const section = usePlotControlsContext();
+  const { sorts, setSorts } = useData((s) => ({
+    sorts: section === "Column" ? s.columnSortOrder : s.rowSortOrder,
+    setSorts: section === "Column" ? s.setColumnSortOrder : s.setRowSortOrder,
+  }));
+
+  const trackEvent = useTrackEvent();
+
+  const allowedSorts = useSortableFields(sorts.map((sort) => sort.key));
+  const filteredSorts = sorts.filter((sort) => allowedSorts.includes(sort.key));
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const handleDragEnd = useEventCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!active || !over) {
+      return;
+    }
+
+    if (active.id !== over.id) {
+      const oldIndex = sorts.findIndex((sort) => sort.key === active.id);
+      const newIndex = sorts.findIndex((sort) => sort.key === over.id);
+
+      const newSorts = arrayMove(sorts, oldIndex, newIndex);
+
+      setSorts(newSorts);
+      trackEvent("Update Sort Order", section, { newSorts });
+    }
+  });
+
+  const sortIsInvalidated = useSortIsInvalidated();
+
+  return (
+    <Accordion
+      id={`sort-options-${usePlotControlsContext()}`}
+      defaultExpanded
+      elevation={0}
+      disableGutters
+      sx={{
+        "&.MuiAccordion-root::before": { display: "none" },
+        scrollMarginTop: 160,
+      }}
+    >
+      <AccordionSummary
+        expandIcon={<ExpandMoreRounded />}
+        sx={{
+          "& .MuiAccordionSummary-content": {
+            alignItems: "center",
+            gap: 1,
+          },
+        }}
+      >
+        <Sort />
+        <Typography variant="subtitle1">Sorts</Typography>
+      </AccordionSummary>
+
+      <AccordionDetails>
+        {sortIsInvalidated ? (
+          <InvalidationAlert />
+        ) : (
+          <Typography variant="body2">
+            Customize how columns are sorted by selecting the primary sorting
+            field. Drag and reorder sorting fields to adjust their priority.
+          </Typography>
+        )}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={sorts.map((s) => s.key)}
+            strategy={verticalListSortingStrategy}
+          >
+            <Stack>
+              {filteredSorts.map((sort, i) => (
+                <SortItem key={sort.key} sort={sort} index={i} />
+              ))}
+            </Stack>
+          </SortableContext>
+        </DndContext>
+        <Stack direction="column">
+          <AddSort />
+          <LeftAlignedButton
+            variant="text"
+            startIcon={<Restore />}
+            {...useResetSorts()}
+          >
+            Reset Sort
+          </LeftAlignedButton>
+        </Stack>
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+const useSortItemActions = () => {
+  const section = usePlotControlsContext();
+  const editSort = useData((s) =>
+    section === "Column" ? s.editColumnSortOrder : s.editRowSortOrder,
+  );
+  const removeSort = useData((s) =>
+    section === "Column" ? s.removeColumnSortOrder : s.removeRowSortOrder,
+  );
+  return { editSort, removeSort };
+};
+
+function SortItem({ sort, index }: { sort: SortOrder<string>; index: number }) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: sort.key });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const { editSort, removeSort } = useSortItemActions();
+
+  const sortText = index === 0 ? "Sort By" : "Then By";
+
+  const availableSorts = useAvailableSorts();
+
+  const onRadioChange = useEventCallback(
+    (_event: React.ChangeEvent<HTMLInputElement>, value: string) => {
+      const direction = value as "asc" | "desc";
+      editSort(index, { ...sort, direction });
+    },
+  );
+
+  const sortIsInvalidated = useSortIsInvalidated();
+
+  const onSelectChange = useEventCallback((event: SelectChangeEvent) => {
+    const key = event.target.value as string;
+    editSort(index, { ...sort, key });
+  });
+
+  const remove = useEventCallback(() => {
+    removeSort(sort.key);
+  });
+  const getFieldDisplayName = useGetFieldDisplayName();
+
+  return (
+    <Stack key={sort.key} style={style} ref={setNodeRef}>
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Icon
+          component={DragHandle}
+          {...attributes}
+          {...listeners}
+          sx={{ cursor: "pointer", mr: 2 }}
+          tabIndex={0}
+        />
+        <Typography variant="subtitle1" noWrap sx={{ flexShrink: 0 }}>
+          {sortText}
+        </Typography>
+        <Select
+          value={sort.key}
+          onChange={onSelectChange}
+          fullWidth
+          disabled={sortIsInvalidated}
+        >
+          {[sort.key, ...availableSorts].map((key) => (
+            <MenuItem key={key} value={key}>
+              {getFieldDisplayName(key)}
+            </MenuItem>
+          ))}
+        </Select>
+        <Button
+          aria-label={`Remove ${sort.key}`}
+          component={IconButton}
+          onClick={remove}
+          disabled={sortIsInvalidated}
+          sx={{
+            minWidth: 0,
+            padding: 0.5,
+            aspectRatio: "1/1",
+          }}
+        >
+          <Close />
+        </Button>
+      </Stack>
+      <FormControl disabled={sortIsInvalidated}>
+        <RadioGroup onChange={onRadioChange} value={sort.direction}>
+          <FormControlLabel
+            value="asc"
+            control={<Radio />}
+            label={
+              <Stack alignItems="center" direction="row" spacing={1}>
+                <ArrowUpwardRounded />
+                <Typography variant="body2">Ascending</Typography>
+              </Stack>
+            }
+          />
+          <FormControlLabel
+            value="desc"
+            control={<Radio />}
+            label={
+              <Stack alignItems="center" direction="row" spacing={1}>
+                <ArrowDownwardRounded />
+                <Typography variant="body2">Descending</Typography>
+              </Stack>
+            }
+          />
+        </RadioGroup>
+      </FormControl>
+    </Stack>
+  );
+}

--- a/src/visx-visualization/plot-controls.tsx/FilterControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/FilterControls.tsx
@@ -22,8 +22,8 @@ import {
   Close,
   DragHandle,
   ExpandMoreRounded,
+  FilterAlt,
   Restore,
-  Sort,
 } from "@mui/icons-material";
 import {
   Accordion,
@@ -90,7 +90,7 @@ function AddSort() {
       disabled={disabled}
       onClick={onClick}
     >
-      Add Sort
+      Add Filter
     </LeftAlignedButton>
   );
 }
@@ -150,7 +150,7 @@ function InvalidationAlert() {
   );
 }
 
-export function SortControls() {
+export function FilterControls() {
   const section = usePlotControlsContext();
   const { sorts, setSorts } = useData((s) => ({
     sorts: section === "Column" ? s.columnSortOrder : s.rowSortOrder,
@@ -191,7 +191,7 @@ export function SortControls() {
 
   return (
     <Accordion
-      id={`sort-options-${usePlotControlsContext()}`}
+      id={`filter-options-${usePlotControlsContext()}`}
       defaultExpanded
       elevation={0}
       disableGutters
@@ -209,8 +209,8 @@ export function SortControls() {
           },
         }}
       >
-        <Sort />
-        <Typography variant="subtitle1">Sorts</Typography>
+        <FilterAlt />
+        <Typography variant="subtitle1">Filters</Typography>
       </AccordionSummary>
 
       <AccordionDetails>
@@ -218,8 +218,7 @@ export function SortControls() {
           <InvalidationAlert />
         ) : (
           <Typography variant="body2">
-            Customize how columns are sorted by selecting the primary sorting
-            field. Drag and reorder sorting fields to adjust their priority.
+            Filter columns by selecting which fields to show from the metadata fields.
           </Typography>
         )}
         <DndContext
@@ -245,7 +244,7 @@ export function SortControls() {
             startIcon={<Restore />}
             {...useResetSorts()}
           >
-            Reset Sort
+            Reset Filter
           </LeftAlignedButton>
         </Stack>
       </AccordionDetails>

--- a/src/visx-visualization/plot-controls.tsx/JumpToSection.tsx
+++ b/src/visx-visualization/plot-controls.tsx/JumpToSection.tsx
@@ -1,4 +1,4 @@
-import { Sort, Visibility } from "@mui/icons-material";
+import { FilterAlt, Sort, Visibility } from "@mui/icons-material";
 import { Link, Typography } from "@mui/material";
 import React from "react";
 export function JumpToSection({ section }: { section: string }) {
@@ -27,6 +27,22 @@ export function JumpToSection({ section }: { section: string }) {
         }}
       >
         <Sort /> Sorts
+      </Link>
+      {" | "}
+      <Link
+        href={`#filter-options-${section}`}
+        display="flex"
+        alignItems="center"
+        underline="none"
+        gap={1}
+        onClick={(e) => {
+          e.preventDefault();
+          document.getElementById(`filter-options-${section}`)?.scrollIntoView({
+            behavior: "smooth",
+          });
+        }}
+      >
+        <FilterAlt /> Filters
       </Link>
       {" | "}
       <Link

--- a/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
+++ b/src/visx-visualization/plot-controls.tsx/PlotControls.tsx
@@ -20,6 +20,7 @@ import {
   useRowConfig,
 } from "../../contexts/AxisConfigContext";
 import { DisplayControls } from "./DisplayControls";
+import { FilterControls } from "./FilterControls";
 import { JumpToSection } from "./JumpToSection";
 import {
   PlotControlsSection,
@@ -52,6 +53,8 @@ function PlotControlSection({
       >
         <Divider />
         <SortControls />
+        <Divider />
+        <FilterControls />
         <Divider />
         <DisplayControls />
       </div>


### PR DESCRIPTION
Adding filters to the options. Each filter is a dropdown, selecting values filters these out. 

Open questions: 
- Does it make more sense to 'reverse' the filter UI, such that the ones that are not selected are filtered out? 
- Could be nice to add the number of items with each value next to the dropdown?
- Currently, you can still order filters, which doesn't change anything. Would there be any scenario where the order of filters matters? Otherwise, we can remove the drag-and-drop UI.
- Sorting has this rowSortInvalidated etc. I don't think Filters can be invalidated, is this correct?