### PR TITLE
NickAkhmetov/Fix embedded graphs for log normalization

### DIFF
--- a/src/visx-visualization/heatmap/Heatmap.tsx
+++ b/src/visx-visualization/heatmap/Heatmap.tsx
@@ -299,9 +299,13 @@ function Heatmap() {
       const cellHeight = Math.ceil(yScale.scale.bandwidth(row));
       if (selectedValues.has(row)) {
         // draw bar graph
-        const max = rowMaxes[row];
+        const max =
+          normalization === "Log" ? Math.log(rowMaxes[row] + 1) : rowMaxes[row];
 
-        const domain = normalization === "None" ? [0, max] : [0, 1];
+        const domain =
+          normalization === "None" || normalization === "Log"
+            ? [0, max]
+            : [0, 1];
 
         const inlineYScale = scaleLinear({
           domain,

--- a/src/visx-visualization/side-graphs/Bars.tsx
+++ b/src/visx-visualization/side-graphs/Bars.tsx
@@ -339,14 +339,16 @@ export default function Bars({
 
     return Array.from(selectedValues)
       .map((key) => {
-        const max = maxes[key];
+        const max =
+          normalization === "Log" ? Math.log(maxes[key] + 1) : maxes[key];
         const scaledPosition = categoricalScale(key);
         const bandwidth = categoricalScale.bandwidth();
 
         if (scaledPosition == null || bandwidth == null) return null;
 
-        const normalizationIsNotNone = normalization !== "None";
-        const domain = normalizationIsNotNone ? [1, 0] : [max, 0];
+        const isPercentNormalized =
+          normalization === "Row" || normalization === "Column";
+        const domain = isPercentNormalized ? [1, 0] : [max, 0];
         const range = [0, expandedSize - EXPANDED_ROW_PADDING * 3];
 
         const axisScale = scaleLinear({
@@ -361,7 +363,7 @@ export default function Bars({
           position: scaledPosition,
           bandwidth,
           max,
-          normalizationIsNotNone,
+          normalizationIsNotNone: isPercentNormalized,
         };
       })
       .filter((axis) => axis !== null);


### PR DESCRIPTION
This PR adjusts the handling for embedded graphs to take log normalization into account when calculating domains/bar sizes.

<img width="1757" height="1863" alt="image" src="https://github.com/user-attachments/assets/b5fb97f8-de58-40dc-a63f-6fcec5eea286" />
