### PR TITLE
Add legend to traditional view

### DIFF
--- a/src/contexts/DimensionsContext.tsx
+++ b/src/contexts/DimensionsContext.tsx
@@ -34,8 +34,8 @@ const DimensionsContext = createContext<DimensionsContextType | null>(
 export type GridSizeTuple = [number, number, number];
 
 export const INITIAL_PROPORTIONS: GridSizeTuple = [0.3, 0.4, 0.3];
-export const TRADITIONAL_COLUMN_PROPORTIONS: GridSizeTuple = [0, 0.95, 0.05];
-export const TRADITIONAL_ROW_PROPORTIONS: GridSizeTuple = [0.9, 0, 0.1];
+export const TRADITIONAL_COLUMN_PROPORTIONS: GridSizeTuple = [0, 0.85, 0.15];
+export const TRADITIONAL_ROW_PROPORTIONS: GridSizeTuple = [1, 0, 0];
 const MIN_PANEL_SIZE = 48;
 
 // Helper function to get the initial size of the panels

--- a/src/contexts/DimensionsContext.tsx
+++ b/src/contexts/DimensionsContext.tsx
@@ -35,7 +35,7 @@ export type GridSizeTuple = [number, number, number];
 
 export const INITIAL_PROPORTIONS: GridSizeTuple = [0.3, 0.4, 0.3];
 export const TRADITIONAL_COLUMN_PROPORTIONS: GridSizeTuple = [0, 0.95, 0.05];
-export const TRADITIONAL_ROW_PROPORTIONS: GridSizeTuple = [1, 0, 0];
+export const TRADITIONAL_ROW_PROPORTIONS: GridSizeTuple = [0.85, 0, 0.15];
 const MIN_PANEL_SIZE = 48;
 
 // Helper function to get the initial size of the panels

--- a/src/contexts/DimensionsContext.tsx
+++ b/src/contexts/DimensionsContext.tsx
@@ -35,7 +35,7 @@ export type GridSizeTuple = [number, number, number];
 
 export const INITIAL_PROPORTIONS: GridSizeTuple = [0.3, 0.4, 0.3];
 export const TRADITIONAL_COLUMN_PROPORTIONS: GridSizeTuple = [0, 0.95, 0.05];
-export const TRADITIONAL_ROW_PROPORTIONS: GridSizeTuple = [0.85, 0, 0.15];
+export const TRADITIONAL_ROW_PROPORTIONS: GridSizeTuple = [0.9, 0, 0.1];
 const MIN_PANEL_SIZE = 48;
 
 // Helper function to get the initial size of the panels

--- a/src/visx-visualization/TraditionalViewRowLegend.tsx
+++ b/src/visx-visualization/TraditionalViewRowLegend.tsx
@@ -1,0 +1,133 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import React from "react";
+import { useRowConfig } from "../contexts/AxisConfigContext";
+import { useData } from "../contexts/DataContext";
+import { getColorForValue } from "../utils/categorical-colors";
+
+interface TraditionalViewRowLegendProps {
+  width: number;
+  height: number;
+}
+
+export default function TraditionalViewRowLegend({
+  width,
+  height,
+}: TraditionalViewRowLegendProps) {
+  const theme = useTheme();
+  const rowConfig = useRowConfig();
+  const rows = useData((s) => s.rowOrder);
+  const removedRows = useData((s) => s.removedRows);
+  const filteredRows = useData((s) => s.filteredRows);
+
+  // Get visible rows (exclude removed and filtered)
+  const visibleRows = rows.filter(
+    (row) => !removedRows.has(row) && !filteredRows.has(row),
+  );
+
+  // Get colors for each row
+  const rowsWithColors = visibleRows.map((row) => ({
+    name: row,
+    color: getColorForValue(row, rows, rowConfig.colors),
+  }));
+
+  console.log("TraditionalViewRowLegend render", { width, height });
+
+  if (visibleRows.length === 0) {
+    console.log("No visible rows, skipping legend render");
+    return null;
+  }
+
+  // Calculate layout - try to fit in multiple columns if there's enough width
+  const itemMinWidth = 120; // Minimum width per legend item
+  const itemHeight = 24; // Height per legend item
+  const padding = 16;
+  const gap = 4;
+
+  // Calculate how many columns we can fit
+  const availableWidth = width - padding * 2;
+  const maxColumns = Math.max(1, Math.floor(availableWidth / itemMinWidth));
+  const actualColumns = Math.min(maxColumns, visibleRows.length);
+
+  // Calculate rows needed
+  const itemsPerColumn = Math.ceil(visibleRows.length / actualColumns);
+  const totalHeight = itemsPerColumn * itemHeight + (itemsPerColumn - 1) * gap;
+
+  return (
+    <Box
+      sx={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "start",
+        zIndex: 1000,
+      }}
+    >
+      {/* Legend Title */}
+      <Typography
+        variant="body2"
+        sx={{
+          color: theme.palette.text.secondary,
+          my: 1,
+          fontWeight: 500,
+        }}
+      >
+        {rowConfig.label}s
+      </Typography>
+
+      {/* Legend Items Grid */}
+      <Box
+        sx={{
+          display: "grid",
+          gridTemplateColumns: `repeat(${actualColumns}, 1fr)`,
+          gap: `${gap}px`,
+          maxHeight: height - 32, // Account for title and padding
+          overflowY: totalHeight > height - 40 ? "auto" : "visible",
+          width: "calc(100% - 16px)",
+          justifyContent: "center",
+        }}
+      >
+        {rowsWithColors.map(({ name, color }) => (
+          <Box
+            key={name}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              minWidth: 0, // Allow text to truncate
+              p: 0.25,
+              border: `1px solid ${theme.palette.divider}`,
+            }}
+          >
+            {/* Color indicator */}
+            <Box
+              sx={{
+                width: 16,
+                height: 16,
+                backgroundColor: color,
+                borderRadius: 1,
+                flexShrink: 0,
+                border: `1px solid ${theme.palette.divider}`,
+              }}
+            />
+            {/* Row name */}
+            <Typography
+              variant="body2"
+              sx={{
+                color: theme.palette.text.primary,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                fontSize: "0.75rem",
+              }}
+              title={name} // Show full name on hover
+            >
+              {name}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+}

--- a/src/visx-visualization/TraditionalViewRowLegend.tsx
+++ b/src/visx-visualization/TraditionalViewRowLegend.tsx
@@ -30,8 +30,6 @@ export default function TraditionalViewRowLegend({
     color: getColorForValue(row, rows, rowConfig.colors),
   }));
 
-  console.log("TraditionalViewRowLegend render", { width, height });
-
   if (visibleRows.length === 0) {
     console.log("No visible rows, skipping legend render");
     return null;
@@ -62,6 +60,10 @@ export default function TraditionalViewRowLegend({
         alignItems: "center",
         justifyContent: "start",
         zIndex: 1000,
+        position: "absolute",
+        top: 0,
+        right: 0,
+        left: 32, // Leave space for scale
       }}
     >
       {/* Legend Title */}
@@ -96,8 +98,6 @@ export default function TraditionalViewRowLegend({
               alignItems: "center",
               gap: 1,
               minWidth: 0, // Allow text to truncate
-              p: 0.25,
-              border: `1px solid ${theme.palette.divider}`,
             }}
           >
             {/* Color indicator */}

--- a/src/visx-visualization/layout/BottomCenter.tsx
+++ b/src/visx-visualization/layout/BottomCenter.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
 import { usePanelDimensions } from "../../contexts/DimensionsContext";
+import { useViewType } from "../../contexts/ViewTypeContext";
 import MetadataValueBar from "../heatmap/MetadataValueBar";
+import TraditionalViewRowLegend from "../TraditionalViewRowLegend";
 import VisualizationPanel, { VisualizationPanelProps } from "./Panel";
 
 function BottomCenterPanel(
@@ -9,9 +11,15 @@ function BottomCenterPanel(
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { width, height } = usePanelDimensions("center_bottom");
+  const { viewType } = useViewType();
+
   return (
     <VisualizationPanel {...props} ref={ref}>
-      <MetadataValueBar axis="X" width={width} height={height} />
+      {viewType === "traditional" ? (
+        <TraditionalViewRowLegend width={width} height={height} />
+      ) : (
+        <MetadataValueBar axis="X" width={width} height={height} />
+      )}
     </VisualizationPanel>
   );
 }

--- a/src/visx-visualization/layout/BottomCenter.tsx
+++ b/src/visx-visualization/layout/BottomCenter.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 
 import { usePanelDimensions } from "../../contexts/DimensionsContext";
-import { useViewType } from "../../contexts/ViewTypeContext";
 import MetadataValueBar from "../heatmap/MetadataValueBar";
-import TraditionalViewRowLegend from "../TraditionalViewRowLegend";
 import VisualizationPanel, { VisualizationPanelProps } from "./Panel";
 
 function BottomCenterPanel(
@@ -11,15 +9,10 @@ function BottomCenterPanel(
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
   const { width, height } = usePanelDimensions("center_bottom");
-  const { viewType } = useViewType();
 
   return (
     <VisualizationPanel {...props} ref={ref}>
-      {viewType === "traditional" ? (
-        <TraditionalViewRowLegend width={width} height={height} />
-      ) : (
-        <MetadataValueBar axis="X" width={width} height={height} />
-      )}
+      <MetadataValueBar axis="X" width={width} height={height} />
     </VisualizationPanel>
   );
 }

--- a/src/visx-visualization/layout/Container.tsx
+++ b/src/visx-visualization/layout/Container.tsx
@@ -129,6 +129,14 @@ const usePanelProps = (id: string) => {
   }, [id]);
 };
 
+const traditionalViewSections = [
+  "left_top",
+  "center_top",
+  "right_top",
+  "center_bottom",
+  "right_bottom",
+];
+
 export default function VizContainerGrid() {
   const { width, height, rowSizes, columnSizes, resizeColumn, resizeRow } =
     useDimensions();
@@ -172,8 +180,7 @@ export default function VizContainerGrid() {
   const shouldRenderPanelChildren = useCallback(
     (section: MappedPanelSection) => {
       if (viewType === "traditional") {
-        // Only top row panels should render their children
-        return section.endsWith("_top");
+        return traditionalViewSections.includes(section);
       }
       // In default view, all panels render their children
       return true;

--- a/src/visx-visualization/layout/Container.tsx
+++ b/src/visx-visualization/layout/Container.tsx
@@ -129,14 +129,6 @@ const usePanelProps = (id: string) => {
   }, [id]);
 };
 
-const traditionalViewSections = [
-  "left_top",
-  "center_top",
-  "right_top",
-  "center_bottom",
-  "right_bottom",
-];
-
 export default function VizContainerGrid() {
   const { width, height, rowSizes, columnSizes, resizeColumn, resizeRow } =
     useDimensions();
@@ -180,7 +172,7 @@ export default function VizContainerGrid() {
   const shouldRenderPanelChildren = useCallback(
     (section: MappedPanelSection) => {
       if (viewType === "traditional") {
-        return traditionalViewSections.includes(section);
+        return section.endsWith("_top");
       }
       // In default view, all panels render their children
       return true;

--- a/src/visx-visualization/layout/TopRight.tsx
+++ b/src/visx-visualization/layout/TopRight.tsx
@@ -1,15 +1,27 @@
 import React from "react";
 
+import { usePanelDimensions } from "../../contexts/DimensionsContext";
+import { useViewType } from "../../contexts/ViewTypeContext";
+import ControlsModalTrigger from "../controls/ControlsModalTrigger";
 import { TopGraphScale } from "../side-graphs/TopGraph";
+import TraditionalViewRowLegend from "../TraditionalViewRowLegend";
 import VisualizationPanel, { VisualizationPanelProps } from "./Panel";
 
 function TopRightPanel(
   props: VisualizationPanelProps,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
+  const viewType = useViewType((state) => state.viewType);
+  const { width, height } = usePanelDimensions("right_top");
   return (
     <VisualizationPanel {...props} ref={ref}>
       <TopGraphScale />
+      {viewType === "traditional" ? (
+        <>
+          <TraditionalViewRowLegend width={width} height={height} />
+          <ControlsModalTrigger />
+        </>
+      ) : null}
     </VisualizationPanel>
   );
 }

--- a/src/visx-visualization/layout/TopRight.tsx
+++ b/src/visx-visualization/layout/TopRight.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-import { useViewType } from "../../contexts/ViewTypeContext";
-import ControlsModalTrigger from "../controls/ControlsModalTrigger";
 import { TopGraphScale } from "../side-graphs/TopGraph";
 import VisualizationPanel, { VisualizationPanelProps } from "./Panel";
 
@@ -9,11 +7,9 @@ function TopRightPanel(
   props: VisualizationPanelProps,
   ref: React.ForwardedRef<HTMLDivElement>,
 ) {
-  const isTraditional = useViewType().viewType === "traditional";
   return (
     <VisualizationPanel {...props} ref={ref}>
       <TopGraphScale />
-      {isTraditional && <ControlsModalTrigger />}
     </VisualizationPanel>
   );
 }


### PR DESCRIPTION
This PR adds a categorical legend for the row colors to be displayed in the traditional view. If not enough vertical space is available, the values are scrollable.

<img width="1676" height="1846" alt="image" src="https://github.com/user-attachments/assets/edb8d06a-985e-47b3-90c6-9f8c86055a9c" />

