### PR TITLE
Fix normalized values displaying as cell counts in tooltip when view is normalized

### DIFF
--- a/src/visx-visualization/heatmap/Heatmap.tsx
+++ b/src/visx-visualization/heatmap/Heatmap.tsx
@@ -11,6 +11,7 @@ import {
   useColumnMetadataKeys,
   useColumns,
   useData,
+  useDataMap,
   useFractionDataMap,
   useMetadataLookup,
   useRowMaxes,
@@ -55,6 +56,7 @@ function Heatmap() {
 
   const colors = useCurrentNormalizedScale();
   const normalization = useNormalization((s) => s.normalization);
+  const countMap = useDataMap();
   const dataMap = useFractionDataMap(normalization);
   const rowMaxes = useRowMaxes();
   const theme = useTheme();
@@ -152,6 +154,7 @@ function Heatmap() {
       }
 
       const key = `${rowKey}-${columnKey}` as keyof typeof dataMap;
+      const rawCount = countMap[key];
       const value = dataMap[key];
 
       let normalizationInfo: Record<string, string> = {};
@@ -186,7 +189,11 @@ function Heatmap() {
         {
           title: `${rowKey} - ${columnKey}`,
           data: {
-            "Cell Count": value,
+            "Cell Count": rawCount,
+            ...(normalization !== "None" && {
+              "Normalized Value": value.toFixed(4),
+              Normalization: normalization,
+            }),
             [rowLabel]: rowKey,
             [columnLabel]: columnKey,
             ...normalizationInfo,
@@ -202,6 +209,7 @@ function Heatmap() {
       isDragging,
       xScale.scale,
       yScale.scale,
+      countMap,
       dataMap,
       normalization,
       lookupMetadata,

--- a/src/visx-visualization/heatmap/Heatmap.tsx
+++ b/src/visx-visualization/heatmap/Heatmap.tsx
@@ -190,10 +190,6 @@ function Heatmap() {
           title: `${rowKey} - ${columnKey}`,
           data: {
             "Cell Count": rawCount,
-            ...(normalization !== "None" && {
-              "Normalized Value": value.toFixed(4),
-              Normalization: normalization,
-            }),
             [rowLabel]: rowKey,
             [columnLabel]: columnKey,
             ...normalizationInfo,

--- a/src/visx-visualization/heatmap/Heatmap.tsx
+++ b/src/visx-visualization/heatmap/Heatmap.tsx
@@ -190,9 +190,9 @@ function Heatmap() {
           title: `${rowKey} - ${columnKey}`,
           data: {
             "Cell Count": rawCount,
+            ...normalizationInfo,
             [rowLabel]: rowKey,
             [columnLabel]: columnKey,
-            ...normalizationInfo,
             ...columnMetadata,
             ...rowMetadata,
           },


### PR DESCRIPTION
<img width="1055" height="655" alt="image" src="https://github.com/user-attachments/assets/08b33579-88df-43f6-a363-a38d9122826a" />
