### PR TITLE
fix: filters for numeric and boolean values, set metadata type explicitly

### DIFF
--- a/src/scellop-schema.ts
+++ b/src/scellop-schema.ts
@@ -51,8 +51,8 @@ export type CountsMatrixValue = [string, string, number];
  * }
  */
 export type Metadata = {
-  rows?: Record<string, Record<string, string | number>>;
-  cols?: Record<string, Record<string, string | number>>;
+  rows?: Record<string, Record<string, string | number | boolean | undefined >>;
+  cols?: Record<string, Record<string, string | number | boolean | undefined >>;
 };
 
 export type DataOrdering = {

--- a/src/visx-visualization/controls/FilterControls.tsx
+++ b/src/visx-visualization/controls/FilterControls.tsx
@@ -208,7 +208,7 @@ function FilterItem({
   });
 
   const onSelectSubFilterChange = useEventCallback(
-    (event: SelectChangeEvent<(string | number | boolean)[]>) => {
+    (event: SelectChangeEvent<(string | number)[]>) => {
       const selectedValues = Array.isArray(event.target.value)
         ? event.target.value
         : [event.target.value];
@@ -270,7 +270,7 @@ function FilterItem({
           {"Values"}
         </Typography>
         <FormControl fullWidth sx={{ mt: 1 }}>
-          <Select<(string | number | boolean)[]>
+          <Select<(string | number)[]>
             multiple
             open={open}
             onClose={() => setOpen(false)}
@@ -287,7 +287,7 @@ function FilterItem({
             </MenuItem>
             <Divider />
             {allSubFilters.map((value) => (
-              <MenuItem key={value.toString()} value={String(value)}>
+              <MenuItem key={value.toString()} value={value}>
                 {value}
               </MenuItem>
             ))}

--- a/src/visx-visualization/heatmap/MetadataValueBar.tsx
+++ b/src/visx-visualization/heatmap/MetadataValueBar.tsx
@@ -127,7 +127,10 @@ export default function MetadataValueBar({
     // Create bars for each sort order
     sortOrder.forEach((sort, sortIndex) => {
       const values = keys.map(
-        (key) => metadata[key]?.[sort.key] || "[No Value]",
+        (key) => {
+          let value = metadata[key]?.[sort.key];
+          return value === undefined ? "undefined" : typeof(value) === "boolean" ? String(value) : value;
+        }
       );
       const isNumeric = keys.every((key) => {
         const value = metadata[key]?.[sort.key];
@@ -141,7 +144,7 @@ export default function MetadataValueBar({
         | null = null;
       if (isNumeric) {
         const numericValues = values.map((v) =>
-          v === "[No Value]" ? 0 : parseInt(v as string, 10),
+          v === "undefined" ? 0 : parseInt(v as string, 10),
         );
         const min = Math.min(...numericValues);
         const max = Math.max(...numericValues);
@@ -159,9 +162,9 @@ export default function MetadataValueBar({
         // Create a consistently sorted domain for stable color assignment
         const uniqueValues = Array.from(new Set(values.map(String)));
         const sortedDomain = uniqueValues.sort((a, b) => {
-          // Sort "[No Value]" to the end, then alphabetically
-          if (a === "[No Value]") return 1;
-          if (b === "[No Value]") return -1;
+          // Sort "undefined" to the end, then alphabetically
+          if (a === "undefined") return 1;
+          if (b === "undefined") return -1;
           return a.localeCompare(b);
         });
 
@@ -195,14 +198,15 @@ export default function MetadataValueBar({
           return acc;
         }
 
-        const value = metadata[key]?.[sort.key] || "[No Value]";
+        let value = metadata[key]?.[sort.key]; 
+        value = value === undefined ? "undefined" : typeof(value) === "boolean" ? String(value) : value;
         const processedValue =
-          isNumeric && value !== "[No Value]"
+          isNumeric && value !== "undefined"
             ? parseInt(value as string, 10)
             : value;
 
         const color =
-          value === "[No Value]"
+          value === "undefined"
             ? theme.palette.grey[400]
             : isNumeric
               ? (colorScale as (value: number) => string)(


### PR DESCRIPTION
**Previous behavior**
- Filters for integers and boolean values did not work. This is because we [converted all to string](https://github.com/hms-dbmi/scellop/blob/9ecc5ff4d571fc697238465ecfb90e1500776ffc/src/visx-visualization/controls/FilterControls.tsx#L290). 

- Filters only showed 'undefined' as an option when there was an explicit 'undefined', not if any of the keys was missing for any of the datasets.

- Datasets failed typechecking when containing any boolean or undefined values.

- Sorting/metadata bars were not shown correctly for boolean values, because of [|| evaluating to false for false](https://github.com/hms-dbmi/scellop/blob/9ecc5ff4d571fc697238465ecfb90e1500776ffc/src/visx-visualization/heatmap/MetadataValueBar.tsx#L198)
<img width="106" height="328" alt="Screenshot 2025-12-18 at 6 57 12 AM" src="https://github.com/user-attachments/assets/b7e3524f-cdcb-4c09-8c5c-a74f8d4fefd8" />



**New behavior**
- Metadata values can be string | number | boolean | undefined

- For filtering and metadata bars, boolean values are converted to strings, and integers as left as is.

- Missing values are included as undefined in filters

- Missing/undefined values are now all "undefined", not "[No Value]", for consistency. 